### PR TITLE
Fixed saving of best_weights

### DIFF
--- a/model_retraining/deepdta/trainer.py
+++ b/model_retraining/deepdta/trainer.py
@@ -12,7 +12,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
 import logging
 import matplotlib.pyplot as plt
-
+from copy import deepcopy
 
 class Dataset(Dataset):
     """
@@ -174,7 +174,7 @@ class Trainer:
             val_loss /= len(val_loader)
             if val_loss < best_val_loss:
                 best_val_loss = val_loss
-                best_weights = self.model.state_dict()
+                best_weights = deepcopy(self.model.state_dict())
                 best_epoch = epoch
                 self.logger.info('Best Model So Far in Epoch: {}'.format(epoch+1))
             self.logger.info('Epoch: {} - Validation Loss: {:.6f}'.format(epoch+1, val_loss))


### PR DESCRIPTION
Hi there. I noticed a small bug in the way DeepDTA is retrained. 
From [this pytorch tutorial](https://pytorch.org/tutorials/beginner/saving_loading_models.html): 
_"If you only plan to keep the best performing model (according to the acquired validation loss), don’t forget that best_model_state = model.state_dict() returns a reference to the state and not its copy! You must serialize best_model_state or use best_model_state = deepcopy(model.state_dict()) otherwise your best best_model_state will keep getting updated by the subsequent training iterations. As a result, the final model state will be the state of the overfitted model."_


Our retraining results in the following RMSE for DeepDTA:
Train: 1.38
Validation: 1.43
Test: 1.68
BDB2020+: 1.71

But you will have to redo the training yourselves, just to be sure. 